### PR TITLE
This accounts for the general perturbations (GP) request class. 

### DIFF
--- a/GpQuery.java
+++ b/GpQuery.java
@@ -1,0 +1,542 @@
+package com.stevenpaligo.spacetrack.client;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.stevenpaligo.spacetrack.client.GpQuery.Gp;
+import com.stevenpaligo.spacetrack.client.GpQuery.GpQueryField;
+import com.stevenpaligo.spacetrack.client.query.QueryField;
+import com.stevenpaligo.spacetrack.client.util.OptionalDateTimeToUtcInstantDeserializer;
+import com.stevenpaligo.spacetrack.client.util.OptionalTinyIntToBooleanDeserializer;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.threeten.extra.scale.UtcInstant;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+public class GpQuery extends Query<GpQueryField, Gp, GpQuery>{
+
+    public GpQuery() {
+        super("gp", Gp.class);
+    }
+
+    /**
+     * Fields referenced in "TLE" queries on <a href="https://www.space-track.org/">Space-Track.org</a>.
+     *
+     * @author Steven Paligo
+     * @see TleQuery
+     */
+    public enum GpQueryField implements QueryField {
+        CCSDS_OMM_VERS {
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.CCSDS_OMM_VERS_JSON_PROPERTY;
+            }
+        },
+        COMMENT {
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.COMMENT_JSON_PROPERTY;
+            }
+        },
+        CREATION_DATE {
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.CREATION_DATE_JSON_PROPERTY;
+            }
+        },
+        ORIGINATOR {
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.ORIGINATOR_JSON_PROPERTY;
+            }
+        },
+        OBJECT_NAME {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.OBJECT_NAME_JSON_PROPERTY;
+            }
+        },
+        OBJECT_ID {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.OBJECT_ID_JSON_PROPERTY;
+            }
+        },
+        CENTER_NAME {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.CENTER_NAME_JSON_PROPERTY;
+            }
+        },
+        REF_FRAME {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.REF_FRAME_JSON_PROPERTY;
+            }
+        },
+        TIME_SYSTEM {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.TIME_SYSTEM_JSON_PROPERTY;
+            }
+        },
+        MEAN_ELEMENT_THEORY {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.MEAN_ELEMENT_THEORY_JSON_PROPERTY;
+            }
+        },
+        EPOCH {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.EPOCH_YMD_HMS_JSON_PROPERTY;
+            }
+        },
+        MEAN_MOTION {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.MEAN_MOTION_JSON_PROPERTY;
+            }
+        },
+        ECCENTRICITY {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.ECCENTRICITY_JSON_PROPERTY;
+            }
+        },
+        INCLINATION {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.INCLINATION_JSON_PROPERTY;
+            }
+        },
+        RA_OF_ASC_NODE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.RIGHT_ASC_OF_NODE_JSON_PROPERTY;
+            }
+        },
+        ARG_OF_PERICENTER {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.ARG_OF_PERICENTER_JSON_PROPERTY;
+            }
+        },
+        MEAN_ANOMALY {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.MEAN_ANOMALY_JSON_PROPERTY;
+            }
+        },
+        EPHEMERIS_TYPE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.EPHEMERIS_TYPE_JSON_PROPERTY;
+            }
+        },
+        CLASSIFICATION_TYPE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.CLASSIFICATION_TYPE_JSON_PROPERTY;
+            }
+        },
+        NORAD_CAT_ID {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.CATALOG_NUMBER_JSON_PROPERTY;
+            }
+        },
+        ELEMENT_SET_NO {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.ELEMENT_SET_NUMBER_JSON_PROPERTY;
+            }
+        },
+        REV_AT_EPOCH {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.REV_AT_EPOCH_JSON_PROPERTY;
+            }
+        },
+        BSTAR {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.BSTAR_JSON_PROPERTY;
+            }
+        },
+        MEAN_MOTION_DOT {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.MEAN_MOTION_DOT_JSON_PROPERTY;
+            }
+        },
+        MEAN_MOTION_DDOT {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.MEAN_MOTION_DOUBLE_DOT_JSON_PROPERTY;
+            }
+        },
+        SEMIMAJOR_AXIS {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.SEMI_MAJOR_AXIS_JSON_PROPERTY;
+            }
+        },
+        PERIOD {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.PERIOD_JSON_PROPERTY;
+            }
+        },
+        APOAPSIS {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.APOAPSIS_JSON_PROPERTY;
+            }
+        },
+        PERIAPSIS {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.PERIAPSIS_JSON_PROPERTY;
+            }
+        },
+        OBJECT_TYPE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.OBJECT_TYPE_JSON_PROPERTY;
+            }
+        },
+        RCS_SIZE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.RCS_SIZE_JSON_PROPERTY;
+            }
+        },
+        COUNTRY_CODE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.COUNTRY_CODE_JSON_PROPERTY;
+            }
+        },
+        LAUNCH_DATE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.LAUNCH_DATE_JSON_PROPERTY;
+            }
+        },
+        SITE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.SITE_JSON_PROPERTY;
+            }
+        },
+        DECAY_DATE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.DECAY_DATE_JSON_PROPERTY;
+            }
+        },
+        FILE {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.FILE_JSON_PROPERTY;
+            }
+        },
+        GP_ID {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.GP_ID_JSON_PROPERTY;
+            }
+        },
+        TLE_LINE0 {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.TLE_LINE_0_JSON_PROPERTY;
+            }
+        },
+
+        TLE_LINE1 {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.TLE_LINE_1_JSON_PROPERTY;
+            }
+        },
+
+        TLE_LINE2 {
+
+            @Override
+            public String getQueryFieldName() {
+
+                return Gp.TLE_LINE_2_JSON_PROPERTY;
+            }
+        },
+    }
+
+
+    /**
+     * Class representing results returned from "TLE" queries on <a href="https://www.space-track.org/">Space-Track.org</a>.
+     *
+     * @author Steven Paligo
+     * @see TleQuery
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Gp {
+        //OMM Header
+        private static final String CCSDS_OMM_VERS_JSON_PROPERTY = "CCSDS_OMM_VERS";
+        private static final String COMMENT_JSON_PROPERTY = "COMMENT";
+        private static final String CREATION_DATE_JSON_PROPERTY = "CREATION_DATE";
+        private static final String ORIGINATOR_JSON_PROPERTY = "ORIGINATOR";
+        //OMM Metadata
+        private static final String OBJECT_NAME_JSON_PROPERTY = "OBJECT_NAME";
+        private static final String OBJECT_ID_JSON_PROPERTY = "OBJECT_ID";
+        private static final String CENTER_NAME_JSON_PROPERTY = "CENTER_NAME";
+        private static final String REF_FRAME_JSON_PROPERTY = "REF_FRAME";
+        private static final String TIME_SYSTEM_JSON_PROPERTY = "TIME_SYSTEM";
+        private static final String MEAN_ELEMENT_THEORY_JSON_PROPERTY = "MEAN_ELEMENT_THEORY";
+        //OMM Data
+        private static final String EPOCH_YMD_HMS_JSON_PROPERTY = "EPOCH";
+        private static final String MEAN_MOTION_JSON_PROPERTY = "MEAN_MOTION";
+        private static final String ECCENTRICITY_JSON_PROPERTY = "ECCENTRICITY";
+        private static final String INCLINATION_JSON_PROPERTY = "INCLINATION";
+        private static final String RIGHT_ASC_OF_NODE_JSON_PROPERTY = "RA_OF_ASC_NODE";
+        private static final String ARG_OF_PERICENTER_JSON_PROPERTY = "ARG_OF_PERICENTER";
+        private static final String MEAN_ANOMALY_JSON_PROPERTY = "MEAN_ANOMALY";
+        private static final String EPHEMERIS_TYPE_JSON_PROPERTY = "EPHEMERIS_TYPE";
+        private static final String CLASSIFICATION_TYPE_JSON_PROPERTY = "CLASSIFICATION_TYPE";
+        private static final String CATALOG_NUMBER_JSON_PROPERTY = "NORAD_CAT_ID";
+        private static final String ELEMENT_SET_NUMBER_JSON_PROPERTY = "ELEMENT_SET_NO";
+        private static final String REV_AT_EPOCH_JSON_PROPERTY = "REV_AT_EPOCH";
+        private static final String BSTAR_JSON_PROPERTY = "BSTAR";
+        private static final String MEAN_MOTION_DOT_JSON_PROPERTY = "MEAN_MOTION_DOT";
+        private static final String MEAN_MOTION_DOUBLE_DOT_JSON_PROPERTY = "MEAN_MOTION_DDOT";
+        private static final String SEMI_MAJOR_AXIS_JSON_PROPERTY = "SEMIMAJOR_AXIS";
+        private static final String PERIOD_JSON_PROPERTY = "PERIOD";
+        private static final String APOAPSIS_JSON_PROPERTY = "APOAPSIS";
+        private static final String PERIAPSIS_JSON_PROPERTY = "PERIAPSIS";
+        private static final String OBJECT_TYPE_JSON_PROPERTY = "OBJECT_TYPE";
+        private static final String RCS_SIZE_JSON_PROPERTY = "RCS_SIZE";
+        private static final String COUNTRY_CODE_JSON_PROPERTY = "COUNTRY_CODE";
+        private static final String LAUNCH_DATE_JSON_PROPERTY = "LAUNCH_DATE";
+        private static final String SITE_JSON_PROPERTY = "SITE";
+        private static final String DECAY_DATE_JSON_PROPERTY = "DECAY_DATE";
+        private static final String FILE_JSON_PROPERTY = "FILE";
+        private static final String GP_ID_JSON_PROPERTY = "GP_ID";
+        private static final String TLE_LINE_0_JSON_PROPERTY = "TLE_LINE0";
+        private static final String TLE_LINE_1_JSON_PROPERTY = "TLE_LINE1";
+        private static final String TLE_LINE_2_JSON_PROPERTY = "TLE_LINE2";
+
+        // OMM Header
+        @JsonProperty(CCSDS_OMM_VERS_JSON_PROPERTY)
+        private String ccsdsOmmVers;
+
+        @JsonProperty(COMMENT_JSON_PROPERTY)
+        private String comment;
+
+        @JsonProperty(value = CREATION_DATE_JSON_PROPERTY)
+        @JsonDeserialize(using = OptionalDateTimeToUtcInstantDeserializer.class)
+        private Optional<UtcInstant> creationDate = Optional.empty();
+
+        @JsonProperty(ORIGINATOR_JSON_PROPERTY)
+        private String originator;
+
+        //OMM Metadata
+        @JsonProperty(OBJECT_NAME_JSON_PROPERTY)
+        private Optional<String> objectName = Optional.empty();
+
+        @JsonProperty(OBJECT_ID_JSON_PROPERTY)
+        private Optional<String> objectId = Optional.empty();
+
+        @JsonProperty(CENTER_NAME_JSON_PROPERTY)
+        private String  centerName;
+
+        @JsonProperty(REF_FRAME_JSON_PROPERTY)
+        private String  refFrame;
+
+        @JsonProperty(TIME_SYSTEM_JSON_PROPERTY)
+        private String timeSystem;
+
+        @JsonProperty(MEAN_ELEMENT_THEORY_JSON_PROPERTY)
+        private String  meanElementTheory;
+
+        // OMM Data
+        @JsonProperty(EPOCH_YMD_HMS_JSON_PROPERTY)
+        @JsonDeserialize(using = OptionalDateTimeToUtcInstantDeserializer.class)
+        private Optional<UtcInstant> epoch = Optional.empty();
+
+        @JsonProperty(MEAN_MOTION_JSON_PROPERTY)
+        private Optional<BigDecimal> meanMotion = Optional.empty();
+
+        @JsonProperty(ECCENTRICITY_JSON_PROPERTY)
+        private Optional<BigDecimal> eccentricity = Optional.empty();
+
+        @JsonProperty(INCLINATION_JSON_PROPERTY)
+        private Optional<BigDecimal> inclination = Optional.empty();
+
+        @JsonProperty(RIGHT_ASC_OF_NODE_JSON_PROPERTY)
+        private Optional<BigDecimal> raOfAscNode = Optional.empty();
+
+        @JsonProperty(ARG_OF_PERICENTER_JSON_PROPERTY)
+        private Optional<BigDecimal> argOfPericenter = Optional.empty();
+
+        @JsonProperty(MEAN_ANOMALY_JSON_PROPERTY)
+        private Optional<BigDecimal> meanAnomaly = Optional.empty();
+
+        @JsonProperty(EPHEMERIS_TYPE_JSON_PROPERTY)
+        private Optional<Integer> ephemerisType = Optional.empty();
+
+        @JsonProperty(CLASSIFICATION_TYPE_JSON_PROPERTY)
+        private Optional<String> classificationType = Optional.empty();
+
+        @JsonProperty(CATALOG_NUMBER_JSON_PROPERTY)
+        private Integer noradCatId;
+
+        @JsonProperty(ELEMENT_SET_NUMBER_JSON_PROPERTY)
+        private Optional<Integer> elementSetNo = Optional.empty();
+
+        @JsonProperty(REV_AT_EPOCH_JSON_PROPERTY)
+        private Optional<Integer> revAtEpoch = Optional.empty();
+
+        @JsonProperty(BSTAR_JSON_PROPERTY)
+        private Optional<BigDecimal> bStar = Optional.empty();
+
+        @JsonProperty(MEAN_MOTION_DOT_JSON_PROPERTY)
+        private Optional<BigDecimal> meanMotionDot = Optional.empty();
+
+        @JsonProperty(MEAN_MOTION_DOUBLE_DOT_JSON_PROPERTY)
+        private Optional<BigDecimal> meanMotionDDot = Optional.empty();
+
+        @JsonProperty(SEMI_MAJOR_AXIS_JSON_PROPERTY)
+        private Optional<Double> semiMajorAxis = Optional.empty();
+
+        @JsonProperty(PERIOD_JSON_PROPERTY)
+        private Optional<Double> period = Optional.empty();
+        /**
+         * Approximate height of the apogee assuming two-body motion and a spherical Earth with radius 6378.135 km
+         */
+        @JsonProperty(APOAPSIS_JSON_PROPERTY)
+        private Optional<Double> apoapsis = Optional.empty();
+
+        /**
+         * Approximate height of the perigee assuming two-body motion and a spherical Earth with radius 6378.135 km
+         */
+        @JsonProperty(PERIAPSIS_JSON_PROPERTY)
+        private Optional<Double> periapsis = Optional.empty();
+
+        @JsonProperty(OBJECT_TYPE_JSON_PROPERTY)
+        private Optional<String> objectType = Optional.empty();
+
+        @JsonProperty(RCS_SIZE_JSON_PROPERTY)
+        private Optional<String> rcsSize = Optional.empty();
+
+        @JsonProperty(COUNTRY_CODE_JSON_PROPERTY)
+        private Optional<String> countryCode = Optional.empty();
+
+        @JsonProperty(LAUNCH_DATE_JSON_PROPERTY)
+        @JsonFormat(pattern = "yyyy-MM-dd", timezone = "UTC")
+        private Optional<LocalDate> launchDate = Optional.empty();
+
+        @JsonProperty(SITE_JSON_PROPERTY)
+        private Optional<String> site = Optional.empty();
+
+        @JsonProperty(DECAY_DATE_JSON_PROPERTY)
+        @JsonDeserialize(using = OptionalTinyIntToBooleanDeserializer.class)
+        private Optional<Boolean> decayDate = Optional.empty();
+
+        @JsonProperty(FILE_JSON_PROPERTY)
+        private Optional<Long> file = Optional.empty();
+
+        @JsonProperty(GP_ID_JSON_PROPERTY)
+        private Integer gpId;
+
+        @JsonProperty(TLE_LINE_0_JSON_PROPERTY)
+        private Optional<String> tleLine0 = Optional.empty();
+
+        @JsonProperty(TLE_LINE_1_JSON_PROPERTY)
+        private Optional<String> tleLine1 = Optional.empty();
+
+        @JsonProperty(TLE_LINE_2_JSON_PROPERTY)
+        private Optional<String> tleLine2 = Optional.empty();
+    }
+}

--- a/GpQueryTest.java
+++ b/GpQueryTest.java
@@ -1,0 +1,52 @@
+package com.stevenpaligo.spacetrack.client;
+
+import com.stevenpaligo.spacetrack.client.credential.CredentialProvider;
+import com.stevenpaligo.spacetrack.client.predicate.InclusiveRange;
+import com.stevenpaligo.spacetrack.client.predicate.Predicate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class GpQueryTest {
+    private static CredentialProvider credentials = TestUtils.getCredentials();
+
+
+    @Test
+    @DisplayName("GpQuery: Result type matches the SpaceTrack schema")
+    public void test1() {
+
+        assertDoesNotThrow(() -> {
+
+            ResultTypeValidator.validate(GpQuery.Gp.class, new URL("https://www.space-track.org/basicspacedata/modeldef/class/gp/format/json"));
+        });
+    }
+
+    @Test
+    @DisplayName("GpQuery: Query field enum matches the result type")
+    public void test2() {
+
+        assertDoesNotThrow(() -> {
+
+            QueryFieldEnumValidator.validate(GpQuery.GpQueryField.class, GpQuery.Gp.class);
+        });
+    }
+
+    @Test
+    @DisplayName("GpQuery: Successful multi call")
+    public void test5() {
+
+        assertDoesNotThrow(() -> {
+
+            Predicate<GpQuery.GpQueryField> predicate1 =
+                    new InclusiveRange<GpQuery.GpQueryField>(GpQuery.GpQueryField.NORAD_CAT_ID, 44713,44715);
+
+            List<GpQuery.Gp> gpQuery = new GpQuery().setCredentials(credentials).addPredicates(Arrays.asList(predicate1)).execute();
+            System.out.println(gpQuery.size());
+        });
+    }
+}

--- a/ResultTypeValidator.java
+++ b/ResultTypeValidator.java
@@ -1,0 +1,263 @@
+/*
+ * The author licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stevenpaligo.spacetrack.client;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URL;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.threeten.extra.scale.UtcInstant;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.NonNull;
+
+public class ResultTypeValidator {
+
+  private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+
+  private ResultTypeValidator() {
+
+    // enforce static method usage
+  }
+
+
+  public static void validate(@NonNull Class<?> resultType, @NonNull URL schemaUrl) throws Exception {
+
+    // filter the result type's fields down to those needing validation
+    // (the static fields are the JSON property names)
+    Field[] resultTypeFields = Arrays.stream(resultType.getDeclaredFields()).filter(f -> Modifier.isStatic(f.getModifiers()) == false).toArray(Field[]::new);
+
+
+    // index the result type fields by their JSON property names
+    Map<String, Field> jsonNameToResultTypeField = new HashMap<>();
+
+    for (Field resultTypeField : resultTypeFields) {
+
+      // get the JsonProperty annotation
+      JsonProperty jsonProperty = resultTypeField.getAnnotation(JsonProperty.class);
+
+      if (jsonProperty == null) {
+
+        throw new Exception("One of the result type fields does not have a @JsonProperty annotation: " + resultTypeField.getName());
+      }
+
+
+      // get the JSON property name
+      String jsonName = jsonProperty.value();
+
+      if (jsonName.equals(JsonProperty.USE_DEFAULT_NAME)) {
+
+        throw new Exception("One of the result type fields does not declare a JSON property name in its @JsonProperty annotation: " + resultTypeField.getName());
+      }
+
+
+      // map the property name to the field
+      Field previouslyMappedField = jsonNameToResultTypeField.put(jsonName, resultTypeField);
+
+      if (previouslyMappedField != null) {
+
+        throw new Exception("One of the result type fields has a duplicate JSON property name in its @JsonProperty annotation: " + resultTypeField.getName());
+      }
+    }
+
+
+    // download the schema from SpaceTrack as JSON
+    JsonNode schema = jsonMapper.readTree(schemaUrl).get("data");
+
+
+    // verify the result type matches the schema
+    if (resultTypeFields.length != schema.size()) {
+
+      throw new Exception("The schema and result type have different numbers of fields (schema: " + schema.size() + ", result type: " + resultTypeFields.length + ")");
+    }
+
+    for (int i = 0; i < schema.size(); i++) {
+
+      JsonNode schemaField = schema.get(i);
+      String schemaFieldName = schemaField.get("Field").asText();
+      String schemaFieldType = schemaField.get("Type").asText();
+      boolean schemaFieldNullable = schemaField.get("Null").asText().equals("YES");
+
+
+      // verify the schema field exists in the result type
+      Field resultTypeField = jsonNameToResultTypeField.get(schemaFieldName);
+
+      if (resultTypeField == null) {
+
+        throw new Exception("The result type is missing a schema field: " + schemaFieldName);
+      }
+
+
+      // verify the result type field is optional if and only if the schema field is nullable
+      boolean resultTypeFieldOptional = resultTypeField.getType().equals(Optional.class);
+
+      if (schemaFieldNullable != resultTypeFieldOptional) {
+
+        if (resultTypeFieldOptional) {
+
+          throw new Exception("A result type field is optional, but its corresponding schema field is not: " + resultTypeField.getName());
+
+        } else {
+
+          throw new Exception("A result type field is required, but its corresponding schema field is not: " + resultTypeField.getName());
+        }
+      }
+
+
+      // verify the data types match unless there is a custom deserializer
+      if (resultTypeField.isAnnotationPresent(JsonDeserialize.class) == false) {
+
+        Class<?> resultFieldDataType;
+
+        if (resultTypeFieldOptional) {
+
+          resultFieldDataType = (Class<?>) ((ParameterizedType) resultTypeField.getGenericType()).getActualTypeArguments()[0];
+
+        } else {
+
+          resultFieldDataType = resultTypeField.getType();
+        }
+
+        if (schemaFieldType.startsWith("bigint(")) {
+
+          if (resultFieldDataType != Long.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.equals("char(1)")) {
+
+          if (resultFieldDataType != String.class && resultFieldDataType != Character.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.startsWith("char(")) {
+
+          if (resultFieldDataType != String.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.equals("date")) {
+
+          if (resultFieldDataType != LocalDate.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.equals("datetime")) {
+
+          if (resultFieldDataType != UtcInstant.class && resultFieldDataType != Instant.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+        } else if (schemaFieldType.startsWith("datetime(")) {
+
+          if (resultFieldDataType != UtcInstant.class && resultFieldDataType != Instant.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        }
+        else if (schemaFieldType.startsWith("decimal(") && schemaFieldType.endsWith(",0)")) {
+
+          if (resultFieldDataType != BigInteger.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.startsWith("decimal(")) {
+
+          if (resultFieldDataType != BigDecimal.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.startsWith("double(") || schemaFieldType.equals("double")) {
+
+          if (resultFieldDataType != Double.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.equals("enum('Y','N')")) {
+
+          if (resultFieldDataType != Boolean.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.startsWith("enum(")) {
+
+          if (resultFieldDataType != String.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.equals("float")) {
+
+          if (resultFieldDataType != Float.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.startsWith("int(") || schemaFieldType.startsWith("mediumint(") || schemaFieldType.startsWith("smallint(") || schemaFieldType.startsWith("tinyint(")) {
+
+          if (resultFieldDataType != Integer.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else if (schemaFieldType.startsWith("varchar(")) {
+
+          if (resultFieldDataType != String.class) {
+
+            throw new Exception("A result field's data type is incompatible with the schema field's type: " + resultTypeField.getName());
+          }
+
+        } else {
+
+          throw new Exception("Unsupported schema field type: " + schemaFieldType);
+        }
+      }
+    }
+
+
+    // verify any optional fields in the result type are initialized by default
+    Object resultTypeInstance = resultType.newInstance();
+
+    for (Field resultTypeField : resultTypeFields) {
+
+      resultTypeField.setAccessible(true);
+
+
+      if (resultTypeField.getType().equals(Optional.class) && resultTypeField.get(resultTypeInstance) == null) {
+
+        throw new Exception("A result field's data type is an `Optional`, but it is not initialized by default: " + resultTypeField.getName());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Also, it allows datetime(6) to be a valid type by accounting for it in ResultTypeValidator. 

All GpQueryTest tests work and cover100% of the code.